### PR TITLE
MMCA-4176 : Upgrade version for Non-HMRC dependencies - July 23 - V5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import sbt.Keys.scalaVersion
 import scoverage.ScoverageKeys
 import uk.gov.hmrc.DefaultBuildSettings.scalaSettings
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
@@ -31,4 +32,5 @@ lazy val scoverageSettings = Seq(
   ScoverageKeys.coverageMinimum := 85,
   ScoverageKeys.coverageFailOnMinimum := true,
   ScoverageKeys.coverageHighlighting := true
+
 )

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -12,8 +12,8 @@ object AppDependencies {
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "bootstrap-test-play-28" % bootstrapVersion % Test,
     "org.pegdown" % "pegdown" % "1.6.0" % "test",
-    "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % "test",
-    "org.mockito" % "mockito-core" % "3.1.0" % "test"
+    "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % "test",
+    "org.mockito" % "mockito-core" % "5.4.0" % "test"
   )
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,5 +4,5 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.20")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")


### PR DESCRIPTION
JIRA Link : https://jira.tools.tax.service.gov.uk/browse/MMCA-4176