### PR TITLE
[MMCA-5273] - Update hmrc-mongo-common library version to fix the bobby warning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,22 +4,22 @@ import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin
 
 val appName = "customs-financials-email-throttler"
 
-val scalaStyleConfigFile = "scalastyle-config.xml"
+val scalaStyleConfigFile     = "scalastyle-config.xml"
 val testScalaStyleConfigFile = "test-scalastyle-config.xml"
-val testDirectory = "test"
+val testDirectory            = "test"
 
-val scala3_3_3 = "3.3.3"
-val bootstrapVersion = "9.1.0"
+val scala3_3_5      = "3.3.5"
 val silencerVersion = "1.7.14"
 
 ThisBuild / majorVersion := 0
-ThisBuild / scalaVersion := scala3_3_3
+ThisBuild / scalaVersion := scala3_3_5
 
 organization := "uk.gov.hmrc"
 
 lazy val scalastyleSettings = Seq(
   scalastyleConfig := baseDirectory.value / "scalastyle-config.xml",
-  (Test / scalastyleConfig) := baseDirectory.value / testDirectory / "test-scalastyle-config.xml")
+  (Test / scalastyleConfig) := baseDirectory.value / testDirectory / "test-scalastyle-config.xml"
+)
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
@@ -29,16 +29,19 @@ lazy val microservice = Project(appName, file("."))
   .settings(
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
     scalacOptions := scalacOptions.value.diff(Seq("-Wunused:all")),
+    scalacOptions += "-Wconf:msg=Flag.*repeatedly:s",
     Test / scalacOptions ++= Seq(
       "-Wunused:imports",
       "-Wunused:params",
       "-Wunused:implicits",
       "-Wunused:explicits",
-      "-Wunused:privates"),
+      "-Wunused:privates"
+    ),
     libraryDependencies ++= Seq(
       compilerPlugin(
         "com.github.ghik" % "silencer-plugin" % silencerVersion
-          cross CrossVersion.for3Use2_13With("", ".12")),
+          cross CrossVersion.for3Use2_13With("", ".12")
+      ),
       "com.github.ghik" % "silencer-lib" % silencerVersion % Provided
         cross CrossVersion.for3Use2_13With("", ".12")
     ),
@@ -64,7 +67,11 @@ lazy val scoverageSettings = Seq(
 lazy val it = project
   .enablePlugins(PlayScala)
   .dependsOn(microservice % "test->test")
-  .settings(libraryDependencies ++= Seq("uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapVersion % Test))
+  .settings(
+    libraryDependencies ++= Seq("uk.gov.hmrc" %% "bootstrap-test-play-30" % AppDependencies.bootstrapVersion % Test)
+  )
 
-addCommandAlias("runAllChecks",
-  ";clean;compile;coverage;test;it/test;scalafmtCheckAll;scalastyle;Test/scalastyle;coverageReport")
+addCommandAlias(
+  "runAllChecks",
+  ";clean;compile;coverage;test;it/test;scalafmtCheckAll;scalastyle;Test/scalastyle;coverageReport"
+)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,17 +2,17 @@ import sbt.*
 
 object AppDependencies {
 
-  val bootstrapVersion = "9.1.0"
-  val mongoVersion = "2.2.0"
+  val bootstrapVersion = "9.11.0"
+  val mongoVersion     = "2.6.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30" % mongoVersion,
-    "uk.gov.hmrc" %% "bootstrap-backend-play-30" % bootstrapVersion
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"        % mongoVersion,
+    "uk.gov.hmrc"       %% "bootstrap-backend-play-30" % bootstrapVersion
   )
 
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapVersion % Test,
-    "org.mockito" % "mockito-core" % "5.11.0" % Test
+    "org.mockito"  % "mockito-core"           % "5.11.0"         % Test
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,15 @@
 resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
-resolvers += Resolver.url("HMRC-open-artefacts-ivy",
-  url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
+resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(
+  Resolver.ivyStylePatterns
+)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.4")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0"
-  exclude("org.scala-lang.modules", "scala-xml_2.12"))
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.24.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"    % "2.6.0")
+addSbtPlugin("org.playframework" % "sbt-plugin"            % "3.0.6")
+addSbtPlugin("org.scoverage"     % "sbt-scoverage"         % "2.0.9")
+addSbtPlugin(
+  "org.scalastyle"              %% "scalastyle-sbt-plugin" % "1.0.0"
+    exclude ("org.scala-lang.modules", "scala-xml_2.12")
+)
+addSbtPlugin("org.scalameta"     % "sbt-scalafmt"          % "2.5.2")


### PR DESCRIPTION
Description - Update hmrc-mongo-common library version to fix the bobby warning and update other library versions to the latest versions

- [x] update library versions
- [x] update build.sbt to fix repeatedly warnings
- [x] minor refactoring and scala formatter changes for relevant files